### PR TITLE
Tolerate additional dependency versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ os:
   - osx
 julia:
   - 1.0
-  - 1.3
-  - 1.4
+  - 1.5
   - nightly
 
 branches:

--- a/Project.toml
+++ b/Project.toml
@@ -17,14 +17,14 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 StatsBase = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
 
 [compat]
-CSV = "^0.7.0"
-DataFrames = "^0.21.8"
-Combinatorics = "^1.0.2"
-Distributions = "^0.24.0"
-FFTW = "^1.2.4"
-RecipesBase = "1.1.0"
-StatsBase = "0.33.2"
-julia = "^1"
+CSV = "0.7.0, 0.8.0"
+DataFrames = "0.21, 0.22"
+Combinatorics = "1"
+Distributions = "0.24"
+FFTW = "1"
+RecipesBase = "1"
+StatsBase = "0.33"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
Care has been taken to accept all dependency
versions that were acceptable before, but many
version constraints have been relaxed significantly.

This is mainly to prevent issues with other Julia packages that
have somehwat narrow dependency version constraints
themselves.

The base-Julia versions used in the CI tests have also been changed to the current stable (=> 1.5), LTS (=> 1.0) and nightly ONLY (but the tests are *all* OK anyway).